### PR TITLE
Update publish workflow to use cargo-binstall for dependencies

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -17,6 +17,9 @@ jobs:
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
       - name: Cache just
         uses: actions/cache@v4
         with:
@@ -38,7 +41,7 @@ jobs:
       - name: Install just
         run: |
           if ! command -v just &> /dev/null; then
-            cargo install just
+            cargo binstall just cargo-license cargo-about
           fi
 
       - name: Build


### PR DESCRIPTION
Replace the installation method for dependencies in the publish workflow with cargo-binstall for improved efficiency.