### PR TITLE
feat: add Vercel deployment entry point crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 notes/
 /target
 lcov.info
+.vercel
+.env*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,18 @@ Both accept `--crates-io-base-url` (env `MCP_CRATES_IO_BASE_URL`) and
 fixtures or registry mirrors. The HTTP subcommand accepts `--bind` (env
 `MCP_BIND_ADDRESS`, default `127.0.0.1:8000`).
 
+A second, unpublished workspace member — `crates/mcp-rust-docs-vercel`
+— is the Vercel deployment entry point (`api/mcp.rs` as a `[[bin]]`,
+per the Vercel Rust runtime's function-discovery convention). It wraps
+the same `Server` in a **stateless** `StreamableHttpService`
+(`NeverSessionManager`, `stateful_mode(false)`, `json_response(true)`)
+because serverless instances can't share `LocalSessionManager`'s
+in-memory sessions, and builds the rmcp `Host` allowlist from Vercel's
+system env vars plus `MCP_ALLOWED_HOSTS` (rmcp defaults to
+loopback-only, which would reject the deployment URL). See that
+crate's README for Vercel project settings. Config knobs stay
+env-only (no clap) to keep the binary thin.
+
 ## Commands
 
 All workflows run through `just` — `cargo` is never invoked directly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -188,6 +188,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-streams"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49debcb7f7400a7f2c96d590795c12372f4db7ad0f518d5a02286d8c8b8c691d"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "serde",
+ "serde_json",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -323,6 +339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -514,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -873,9 +899,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1163,6 +1192,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcp-rust-docs-vercel"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "mcp-rust-docs",
+ "rmcp",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "vercel_runtime",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1272,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2076,7 +2119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2139,6 +2182,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2210,6 +2274,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2435,6 +2500,28 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vercel_runtime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9040702f825410b853e11779c07d90c826ba17fdf3a3df47902c3c6dd3f724f"
+dependencies = [
+ "axum",
+ "axum-streams",
+ "base64",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+]
 
 [[package]]
 name = "want"
@@ -2681,6 +2768,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ ruzstd = { version = "0.8", default-features = false, features = ["std"] }
 rustdoc-types = "0.57"
 rustdoc-types-56 = { package = "rustdoc-types", version = "=0.56.0" }
 moka = { version = "0.12", features = ["future"] }
+# Vercel deployment entry point (crates/mcp-rust-docs-vercel) only.
+vercel_runtime = { version = "2.4", features = ["axum"] }
+tower = "0.5"
 
 [workspace.lints.clippy]
 unwrap_used = "deny"

--- a/crates/mcp-rust-docs-vercel/Cargo.toml
+++ b/crates/mcp-rust-docs-vercel/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "mcp-rust-docs-vercel"
+version = "0.1.0"
+publish = false
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Vercel Fluid-compute deployment entry point for mcp-rust-docs."
+
+[lints]
+workspace = true
+
+[dependencies]
+mcp-rust-docs = { path = "../mcp-rust-docs" }
+rmcp = { workspace = true }
+tokio = { workspace = true }
+axum = { workspace = true }
+tower = { workspace = true }
+vercel_runtime = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+# Vercel's Rust builder discovers functions through [[bin]] entries whose
+# paths live under api/. The binary name becomes the function route
+# (/api/mcp), which vercel.json rewrites /mcp onto.
+[[bin]]
+name = "mcp"
+path = "api/mcp.rs"

--- a/crates/mcp-rust-docs-vercel/README.md
+++ b/crates/mcp-rust-docs-vercel/README.md
@@ -1,0 +1,32 @@
+# mcp-rust-docs-vercel
+
+Vercel deployment entry point for [`mcp-rust-docs`](../mcp-rust-docs).
+Not published to crates.io.
+
+Serves the streamable-HTTP MCP transport at `/mcp` on Vercel's Rust
+runtime (public beta, Fluid compute), in **stateless mode** — see the
+doc comment in [`api/mcp.rs`](api/mcp.rs) for why.
+
+## Vercel project settings
+
+| Setting                                            | Value                                    |
+| -------------------------------------------------- | ---------------------------------------- |
+| Root Directory                                     | `crates/mcp-rust-docs-vercel`            |
+| "Include files outside the root directory" | **On** (the crate builds via the workspace root) |
+
+## Environment variables
+
+All optional:
+
+| Variable                 | Purpose                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `MCP_CRATES_IO_BASE_URL` | Override the crates.io base URL (mirrors, proxies).                                              |
+| `MCP_DOCS_RS_BASE_URL`   | Override the docs.rs base URL.                                                                   |
+| `MCP_DOCS_RS_CACHE`      | `false` disables the in-process rustdoc-JSON cache.                                              |
+| `MCP_ALLOWED_HOSTS`      | Comma-separated extra `Host` values, e.g. custom domains. Vercel's own URLs are picked up automatically from `VERCEL_URL` / `VERCEL_BRANCH_URL` / `VERCEL_PROJECT_PRODUCTION_URL`. |
+
+## Routing
+
+`vercel.json` rewrites every path to the single `/api/mcp` function;
+the axum router inside only answers on `/mcp`. Point MCP clients at
+`https://<deployment>/mcp`.

--- a/crates/mcp-rust-docs-vercel/api/mcp.rs
+++ b/crates/mcp-rust-docs-vercel/api/mcp.rs
@@ -1,0 +1,172 @@
+//! Vercel entry point for the MCP server.
+//!
+//! Serves the same streamable-HTTP transport as `mcp-rust-docs http`,
+//! adapted for serverless execution:
+//!
+//! - **Stateless mode.** Consecutive requests from one client can land
+//!   on different Fluid-compute instances, so `Mcp-Session-Id` sessions
+//!   held in one instance's memory would 404 on the next. All four
+//!   tools are pure request/response (no sampling, elicitation, or
+//!   subscriptions), so nothing is lost by disabling sessions.
+//! - **Plain JSON responses** instead of SSE framing — allowed by the
+//!   Streamable HTTP spec (2025-06-18) and cheaper for single-shot
+//!   tool calls.
+//! - **Host allowlist from Vercel env vars.** rmcp's DNS-rebinding
+//!   guard defaults to loopback-only, which would reject every request
+//!   arriving via the deployment URL. See [`allowed_hosts`].
+
+use mcp_rust_docs::{CRATES_IO_BASE_URL, DOCS_RS_BASE_URL, Server};
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::never::NeverSessionManager,
+};
+use tower::ServiceBuilder;
+use tracing_subscriber::EnvFilter;
+use vercel_runtime::axum::VercelLayer;
+
+#[tokio::main]
+async fn main() -> Result<(), vercel_runtime::Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let env = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
+
+    let crates_io_base_url =
+        env("MCP_CRATES_IO_BASE_URL").unwrap_or_else(|| CRATES_IO_BASE_URL.to_string());
+    let docs_rs_base_url =
+        env("MCP_DOCS_RS_BASE_URL").unwrap_or_else(|| DOCS_RS_BASE_URL.to_string());
+    let docs_rs_cache = env("MCP_DOCS_RS_CACHE").is_none_or(|value| value != "false");
+    let allowed_hosts = allowed_hosts(&env);
+
+    tracing::info!(
+        %crates_io_base_url,
+        %docs_rs_base_url,
+        %docs_rs_cache,
+        ?allowed_hosts,
+        "starting mcp-rust-docs on Vercel",
+    );
+
+    // Build the Server (and its `reqwest::Client`) ONCE and clone it in
+    // the factory, same as `run_http` in the main binary — cloning is
+    // cheap (use cases are behind `Arc`s) and reuses the connection
+    // pool across requests handled by this instance.
+    let server_template = Server::builder()
+        .crates_io_base_url(crates_io_base_url)
+        .docs_rs_base_url(docs_rs_base_url)
+        .docs_rs_cache_enabled(docs_rs_cache)
+        .build()?;
+
+    let service = StreamableHttpService::new(
+        move || Ok(server_template.clone()),
+        NeverSessionManager::default().into(),
+        StreamableHttpServerConfig::default()
+            .with_stateful_mode(false)
+            .with_json_response(true)
+            .with_allowed_hosts(allowed_hosts),
+    );
+
+    // Rewrites preserve the original request path, so the router sees
+    // `/mcp`, not `/api/mcp` — mount at the public path.
+    let router = axum::Router::new().nest_service("/mcp", service);
+
+    let app = ServiceBuilder::new()
+        .layer(VercelLayer::new())
+        .service(router);
+    vercel_runtime::run(app).await
+}
+
+/// Assemble the `Host`-header allowlist for rmcp's DNS-rebinding guard.
+///
+/// Vercel publishes its own hostnames through system env vars
+/// (`VERCEL_URL` for this deployment, `VERCEL_BRANCH_URL` /
+/// `VERCEL_PROJECT_PRODUCTION_URL` for the stable aliases), so those
+/// are folded in automatically. Custom domains are not exposed that
+/// way — list them in the comma-separated `MCP_ALLOWED_HOSTS`.
+/// Loopback hosts stay allowed so `vercel dev` keeps working.
+fn allowed_hosts(env: &impl Fn(&str) -> Option<String>) -> Vec<String> {
+    let mut hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+
+    for key in [
+        "VERCEL_URL",
+        "VERCEL_BRANCH_URL",
+        "VERCEL_PROJECT_PRODUCTION_URL",
+    ] {
+        hosts.extend(env(key));
+    }
+
+    if let Some(extra) = env("MCP_ALLOWED_HOSTS") {
+        hosts.extend(
+            extra
+                .split(',')
+                .map(str::trim)
+                .filter(|host| !host.is_empty())
+                .map(String::from),
+        );
+    }
+
+    hosts.sort();
+    hosts.dedup();
+    hosts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::allowed_hosts;
+
+    fn env_from<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| (*v).to_string())
+        }
+    }
+
+    #[test]
+    fn defaults_to_loopback_only_without_vercel_env() {
+        let hosts = allowed_hosts(&env_from(&[]));
+        assert_eq!(hosts, ["127.0.0.1", "::1", "localhost"]);
+    }
+
+    #[test]
+    fn folds_in_vercel_system_urls() {
+        let hosts = allowed_hosts(&env_from(&[
+            ("VERCEL_URL", "app-abc123.vercel.app"),
+            ("VERCEL_PROJECT_PRODUCTION_URL", "app.vercel.app"),
+        ]));
+        assert!(hosts.contains(&"app-abc123.vercel.app".to_string()));
+        assert!(hosts.contains(&"app.vercel.app".to_string()));
+    }
+
+    #[test]
+    fn splits_and_trims_mcp_allowed_hosts() {
+        let hosts = allowed_hosts(&env_from(&[(
+            "MCP_ALLOWED_HOSTS",
+            "docs.example.com , api.example.com,,",
+        )]));
+        assert!(hosts.contains(&"docs.example.com".to_string()));
+        assert!(hosts.contains(&"api.example.com".to_string()));
+        assert!(!hosts.contains(&"".to_string()));
+    }
+
+    #[test]
+    fn deduplicates_overlapping_sources() {
+        let hosts = allowed_hosts(&env_from(&[
+            ("VERCEL_URL", "app.vercel.app"),
+            ("MCP_ALLOWED_HOSTS", "app.vercel.app"),
+        ]));
+        assert_eq!(
+            hosts
+                .iter()
+                .filter(|host| *host == "app.vercel.app")
+                .count(),
+            1
+        );
+    }
+}

--- a/crates/mcp-rust-docs-vercel/vercel.json
+++ b/crates/mcp-rust-docs-vercel/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/api/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `crates/mcp-rust-docs-vercel`, an unpublished workspace member that deploys the MCP server to Vercel's Rust runtime (public beta, Fluid compute). The published `mcp-rust-docs` crate is untouched apart from the shared `Cargo.lock`/workspace-dependency additions.

- **`api/mcp.rs`** — single `[[bin]]` function entrypoint per the Vercel Rust runtime's discovery convention, wrapping the existing `Server` with `vercel_runtime`'s axum `VercelLayer`.
- **Stateless transport** — `NeverSessionManager` + `stateful_mode(false)` + `json_response(true)`. Serverless instances can't share `LocalSessionManager`'s in-memory sessions (consecutive requests may land on different instances), and all four tools are pure request/response, so sessions add nothing.
- **Host allowlist** — rmcp's DNS-rebinding guard defaults to loopback-only, which would reject every request at the deployment URL. The allowlist is assembled from Vercel system env vars (`VERCEL_URL`, `VERCEL_BRANCH_URL`, `VERCEL_PROJECT_PRODUCTION_URL`) plus comma-separated `MCP_ALLOWED_HOSTS` for custom domains; unit-tested.
- **`vercel.json`** — rewrites all paths to the `/api/mcp` function; clients connect at `/mcp` (rewrites preserve the original path).
- Existing env knobs (`MCP_CRATES_IO_BASE_URL`, `MCP_DOCS_RS_BASE_URL`, `MCP_DOCS_RS_CACHE`) carry over, env-only (no clap).
- Ignores `.vercel/` and `.env*` artifacts from `vercel link`/`vercel dev`.

Vercel project settings required (documented in the crate README): Root Directory = `crates/mcp-rust-docs-vercel` with "Include source files outside of the Root Directory" enabled, since the crate resolves dependencies through the workspace root.

## Test plan

- [x] `just ci` (fmt-check, clippy `-D warnings`, hermetic tests — includes 4 new unit tests for allowlist assembly)
- [ ] Vercel deploy: verify `initialize` + `tools/list` against the deployment URL (the beta Rust builder's cargo-workspace handling is the untested assumption; fallback is a self-contained crate with its own lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)